### PR TITLE
Fix SSLv3 override

### DIFF
--- a/src/main/java/com/terminaldriver/tn5250j/TerminalDriver.java
+++ b/src/main/java/com/terminaldriver/tn5250j/TerminalDriver.java
@@ -168,7 +168,7 @@ public class TerminalDriver implements Closeable {
 		sessionProperties.put("SESSION_HOST", host);
 		sessionProperties.put("SESSION_HOST_PORT", String.valueOf(port));
 		sessionProperties.put("SESSION_CODE_PAGE", codePage);
-		sessionProperties.put(TN5250jConstants.SSL_TYPE, TN5250jConstants.SSL_TYPE_SSLv3);
+		sessionProperties.put(TN5250jConstants.SSL_TYPE, sslType);
 
 		TN5250jLogFactory.setLogLevels(TN5250jLogger.INFO);
 


### PR DESCRIPTION
SSLv3 was selected during the connection even if no SSL was configured via properties map or setSslType